### PR TITLE
start at end of file (original behavior)

### DIFF
--- a/tail.py
+++ b/tail.py
@@ -49,7 +49,7 @@ class Tail(object):
 
         with open(self.tailed_file, self.open_mode) as file_:
             # Go to the end of file
-            file_.seek(0,0)
+            file_.seek(0,2)
             while True:
                 curr_position = file_.tell()
                 line = file_.readline()


### PR DESCRIPTION
Last commit accidentally checked in a debug change where I started the initial seek at the beginning of the file instead of the end.  Restoring this to the end so that the only delta is just the binary support intended.